### PR TITLE
feat: Simplify to raw sqrtPriceX96 output and use BigInt (v0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ All DEX packages output the same `TickerOutput` format defined in `proto/dex_com
 - Simple integration of new DEXes
 
 The ticker format provides block-aggregated data including:
-- Token volumes (raw units)
+- Token volumes (raw units as integers)
 - Swap counts
-- Closing prices
+- sqrtPriceX96 (raw price data - clients must calculate actual price)
 - Block number and timestamp
+
+**Note**: All numerical values (volumes, prices) are provided as raw blockchain values. Clients must apply decimal adjustments and price calculations based on token decimals.
 
 ## Supported DEXes
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,70 +1,10 @@
 use num_bigint::BigInt as NumBigInt;
-use std::str::FromStr;
-use substreams::scalar::{BigDecimal, BigInt};
+use substreams::scalar::BigInt;
 
-/// Calculate actual price from sqrtPriceX96 format used by Uniswap V3 and compatible DEXes
-///
-/// ## Why DEXes store price as sqrtPriceX96:
-///
-/// 1. **Gas Efficiency**: Calculations with square roots reduce computational complexity
-/// 2. **Solidity Limitations**: No floating-point numbers in Solidity, so fixed-point is used
-/// 3. **Q64.96 Format**: A 256-bit number where 64 bits represent the integer part and 96 bits
-///    represent the fractional part, allowing for high precision without decimals
-/// 4. **Storage Optimization**: 2^96 was chosen as the largest precision that fits efficiently
-///    in contract storage slots, allowing multiple values to be packed together
-///
-/// ## The Math:
-/// - sqrtPriceX96 = sqrt(price) * 2^96
-/// - Therefore: price = (sqrtPriceX96 / 2^96)^2
-/// - This gives us the price of token1 in terms of token0
-///
-/// ## Example:
-/// If sqrtPriceX96 = 79228162514264337593543950336 (which is 2^96)
-/// Then price = (2^96 / 2^96)^2 = 1^2 = 1 (tokens are equal value)
+/// Format BigInt as a string, handling potential edge cases
 #[inline]
-pub fn calculate_price_from_sqrt_x96(sqrt_price_x96: &BigDecimal) -> BigDecimal {
-    // 2^96 as a decimal constant
-    let two_96 = BigDecimal::from_str("79228162514264337593543950336").unwrap();
-
-    // Divide by 2^96 to get the actual square root of price
-    let sqrt_price = sqrt_price_x96.clone() / two_96;
-
-    // Square it to get the actual price
-    sqrt_price.clone() * sqrt_price
-}
-
-/// Format BigDecimal with at most 18 decimal places, removing trailing zeros
-/// Handles scientific notation gracefully
-#[inline]
-pub fn format_bigdecimal(value: &BigDecimal) -> String {
-    let mut s = value.to_string();
-
-    // Handle scientific notation - return as-is
-    if s.contains('e') || s.contains('E') {
-        return s;
-    }
-
-    if let Some(decimal_point_index) = s.find('.') {
-        // Truncate to maximum 18 decimal places
-        let truncate_position = usize::min(decimal_point_index + 1 + 18, s.len());
-        s.truncate(truncate_position);
-
-        // Remove trailing zeros
-        while s.ends_with('0') {
-            s.pop();
-        }
-
-        // Remove decimal point if no decimals remain
-        if s.ends_with('.') {
-            s.pop();
-        }
-    }
-
-    if s.is_empty() {
-        "0".to_string()
-    } else {
-        s
-    }
+pub fn format_bigint(value: &BigInt) -> String {
+    value.to_string()
 }
 
 /// Ensure address has 0x prefix
@@ -77,29 +17,29 @@ pub fn ensure_0x_prefix(address: &str) -> String {
     }
 }
 
-/// Convert signed int256 bytes to BigDecimal
+/// Convert signed int256 bytes to BigInt
 ///
 /// ## EVM Integer Storage:
 /// - Integers in the EVM are stored as 32-byte (256-bit) words
 /// - Signed integers use two's complement representation
-/// - This function handles the conversion from raw bytes to a decimal value
+/// - This function handles the conversion from raw bytes to BigInt
 ///
 /// ## Parameters:
 /// - `bytes`: Must be exactly 32 bytes representing a signed 256-bit integer
 ///
 /// ## Returns:
-/// - The decimal representation of the integer, or 0 if invalid input
+/// - The BigInt representation of the integer, or 0 if invalid input
 #[inline]
-pub fn int256_to_bigdecimal(bytes: &[u8]) -> BigDecimal {
+pub fn int256_to_bigint(bytes: &[u8]) -> BigInt {
     if bytes.len() != 32 {
-        return BigDecimal::zero();
+        return BigInt::zero();
     }
 
     let bigint = NumBigInt::from_signed_bytes_be(bytes);
-    BigDecimal::from(BigInt::from(bigint))
+    BigInt::from(bigint)
 }
 
-/// Convert unsigned uint160 bytes (stored in 32 bytes) to BigDecimal
+/// Convert unsigned uint160 bytes (stored in 32 bytes) to BigInt
 ///
 /// ## Why uint160:
 /// - Ethereum addresses are 160 bits (20 bytes)
@@ -110,15 +50,15 @@ pub fn int256_to_bigdecimal(bytes: &[u8]) -> BigDecimal {
 /// - `bytes`: Must be exactly 32 bytes with uint160 in the last 20 bytes
 ///
 /// ## Returns:
-/// - The decimal representation of the uint160 value, or 0 if invalid input
+/// - The BigInt representation of the uint160 value, or 0 if invalid input
 #[inline]
-pub fn uint160_to_bigdecimal(bytes: &[u8]) -> BigDecimal {
+pub fn uint160_to_bigint(bytes: &[u8]) -> BigInt {
     if bytes.len() != 32 {
-        return BigDecimal::zero();
+        return BigInt::zero();
     }
 
     // uint160 is stored in the last 20 bytes of the 32-byte word
     let start = bytes.len().saturating_sub(20);
     let bigint = NumBigInt::from_bytes_be(num_bigint::Sign::Plus, &bytes[start..]);
-    BigDecimal::from(BigInt::from(bigint))
+    BigInt::from(bigint)
 }

--- a/dexes/uniswap-v3-forks/README.md
+++ b/dexes/uniswap-v3-forks/README.md
@@ -89,15 +89,23 @@ Aggregates swap data per pool per block, providing:
 - Closing price (calculated from sqrtPriceX96)
 - Block number and timestamp
 
-## Volume Format
+## Output Format
 
-**Important**: Volumes are reported in raw token units (not decimal-adjusted).
+This implementation outputs a `TickerOutput` message containing aggregated swap data for each pool that had activity in the block:
+
+### Volume Data
+- **Volumes are raw token units** (not decimal-adjusted)
 - Example: 500 USDC (6 decimals) is reported as "500000000"
 - Consumers must divide by 10^decimals to get actual token amounts
 
-## Output Format
-
-This implementation outputs a `TickerOutput` message containing aggregated swap data for each pool that had activity in the block. The output focuses purely on trading metrics, providing volumes, swap counts, and closing prices
+### Price Data
+- **Price is provided as sqrtPriceX96** - the raw value from swap events
+- This is NOT a human-readable price
+- Clients must calculate the actual price using:
+  ```
+  price = (sqrtPriceX96 / 2^96)^2 * 10^(token0_decimals - token1_decimals)
+  ```
+- The sqrtPriceX96 format is standard across all Uniswap V3 forks
 
 ## Building
 

--- a/dexes/uniswap-v3-forks/substreams.yaml
+++ b/dexes/uniswap-v3-forks/substreams.yaml
@@ -2,7 +2,7 @@ specVersion: v0.1.0
 
 package:
   name: coinranking_uniswap_v3_forks
-  version: v0.1.0
+  version: v0.2.0
   url: https://github.com/coinranking/substreams
   image: assets/coinranking-logo.png
   description: "Real-time block-aggregated swap data for Uniswap V3 and compatible forks"

--- a/proto/dex_common.proto
+++ b/proto/dex_common.proto
@@ -13,12 +13,13 @@ message PoolTicker {
   string pool_address = 1;
 
   // Block-level volume aggregates (sum of all swaps in this block)
-  string block_volume_token0 = 2;  // Total token0 volume in this block
-  string block_volume_token1 = 3;  // Total token1 volume in this block
+  string block_volume_token0 = 2;  // Total token0 volume in this block (raw token units as integer)
+  string block_volume_token1 = 3;  // Total token1 volume in this block (raw token units as integer)
   uint32 swap_count = 4;           // Number of swaps for this pool in this block
 
-  // Price data (token0 per token1)
-  string close_price = 5;    // Final price in this block
+  // Price data - raw sqrtPriceX96 from last swap
+  // Client must calculate: price = (sqrtPriceX96 / 2^96)^2 * 10^(decimals0 - decimals1)
+  string sqrt_price_x96 = 5;      // sqrtPriceX96 value from last swap in block
 
   // Metadata
   uint64 block_number = 6;


### PR DESCRIPTION
## Breaking Changes - Version 0.2.0 🚀

This PR simplifies the substreams output to be a pure data extractor, moving all calculations to the client side.

## Key Changes

### 📊 Output Format Changes
- **Before**: Calculated `close_price` field  
- **After**: Raw `sqrt_price_x96` field directly from blockchain
- Clients now calculate price using: `price = (sqrtPriceX96 / 2^96)^2 * 10^(token0_decimals - token1_decimals)`

### 🔧 Type Clarity Improvements
- Changed from `BigDecimal` to `BigInt` for all integer values
- Renamed functions: `int256_to_bigdecimal` → `int256_to_bigint`
- Removed confusing decimal types for integer data
- Clearer distinction between integers (volumes) and actual decimals

### 🎯 Simplifications
- Removed `calculate_price_from_sqrt_x96` function
- No more price calculations in substreams
- Simpler, more maintainable code
- More accurate (no precision loss)

## Benefits
- ✅ **Pure data extraction** - substreams just extracts, clients interpret
- ✅ **More accurate** - no precision loss from calculations
- ✅ **Clearer types** - BigInt for integers only
- ✅ **Client flexibility** - clients control calculation precision
- ✅ **Smaller code** - less logic, fewer dependencies

## Migration Guide

Clients need to update to:
1. Read `sqrt_price_x96` instead of `close_price`
2. Calculate price client-side using the formula above
3. Have token decimals available for price calculation

## Testing
```bash
cd dexes/uniswap-v3-forks
cargo build --target wasm32-unknown-unknown --release
./test.sh
```

Build successful ✅

## Ready for Publishing
Once merged, this can be published as v0.2.0 to the Substreams registry.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added block timestamp to pool ticker outputs.
- Refactor
  - Price output now exposes raw sqrtPriceX96 instead of a computed close price; clients must derive human-readable prices.
  - Volumes and prices standardized as raw integer values; clients must apply token decimals.
- Documentation
  - Updated READMEs to clarify raw integer volumes and sqrtPriceX96 price data, with guidance on client-side calculations.
- Chores
  - Bumped Uniswap V3 forks package version to v0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->